### PR TITLE
WIP: v1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ $ wget https://raw.githubusercontent.com/nelqatib/mbed-vim/master/plugin/mbed.vi
 * Compiling the current application with different options (clean, verbose mode, etc.) and displaying the
 output when the compilation is unseccessful.
 
-* Adding/Removing a library
+* Adding/Removing a library.
 
-* Setting the application's target/toolchain
+* Setting the application's target/toolchain.
 
-* Synchronize the dependencies.
+* Synchronizing the different dependencies.
 
-* Run tests.
+* Running tests.
 
 ### Default key mappings
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mbed-vim
 
-[![version](https://img.shields.io/badge/version-v0.2-red.svg)](https://github.com/nelqatib/mbed-vim/releases)
+[![version](https://img.shields.io/badge/version-v1.0-red.svg)](https://github.com/nelqatib/mbed-vim/releases)
 [![Build Status](https://travis-ci.org/nelqatib/mbed-vim.svg?branch=master)](https://travis-ci.org/nelqatib/mbed-vim)
 [![license](http://img.shields.io/badge/license-mit-blue.svg)](https://opensource.org/licenses/MIT)
 
@@ -15,13 +15,24 @@ $ git clone git@github.com:marrakchino/mbed-vim.git
 $ cp mbed-vim/plugin/mbed.vim ~/.vim/plugin
 ```
 
-* By downloading and saving the plugin file in your `plugin` directory
+* By downloading and saving the plugin file in your `plugin` directory using `wget`
 
 ```sh
 $ wget https://raw.githubusercontent.com/nelqatib/mbed-vim/master/plugin/mbed.vim -O ~/.vim/plugin/mbed.vim
 ```
 
 ## Features
+
+* Compiling the current application with different options (clean, verbose mode, etc.) and displaying the
+output when the compilation is unseccessful.
+
+* Adding/Removing a library
+
+* Setting the application's target/toolchain
+
+* Synchronize the dependencies.
+
+* Run tests.
 
 ### Default key mappings
 
@@ -37,7 +48,7 @@ $ wget https://raw.githubusercontent.com/nelqatib/mbed-vim/master/plugin/mbed.vi
 <leader>d:   Import missing dependencies.
 <leader>a:   Prompt for an mbed library to add.
 <leader>r:   Prompt for an mbed library to remove.
-<leader>l:   Display dependency tree
+<leader>l:   Display the dependency tree.
 <F9>:        Close the error buffer (when open).
 <F12>:       Set the current application's target and toolchain.
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ $ git clone git@github.com:marrakchino/mbed-vim.git
 $ cp mbed-vim/plugin/mbed.vim ~/.vim/plugin
 ```
 
-* By downloading and saving the plugin file in your `plugin` directory using `wget`
+* By downloading the plugin file to your **plugin** directory using `wget`
 
 ```sh
 $ wget https://raw.githubusercontent.com/nelqatib/mbed-vim/master/plugin/mbed.vim -O ~/.vim/plugin/mbed.vim

--- a/plugin/mbed.vim
+++ b/plugin/mbed.vim
@@ -47,8 +47,6 @@
 "   is opened. You can close this buffer with <F9>. 
 "
 
-" Global variables
-" XXX: variables should be local to the current window or global?
 if !exists( "w:mbed_target" )
   let w:mbed_target = ""
 endif
@@ -58,7 +56,7 @@ if !exists( "w:mbed_toolchain" )
 endif
 
 function! MbedGetTargetandToolchain( force )
-  let l:mbed_tools_exist = system("which mbed")
+  call system("which mbed")
   if v:shell_error != 0
     echoe "Couldn't find mbed CLI tools."
     return

--- a/plugin/mbed.vim
+++ b/plugin/mbed.vim
@@ -95,7 +95,7 @@ function! MbedGetTargetandToolchain( force )
         return
       endif
     endif
-    let w:mbed_toolchain = substitute(substitute(l:target, '\[[^]]*\] ', '', 'g'), '\n', '', 'g')
+    let w:mbed_toolchain = substitute(substitute(l:toolchain, '\[[^]]*\] ', '', 'g'), '\n', '', 'g')
   endif
 endfunction
 

--- a/plugin/mbed.vim
+++ b/plugin/mbed.vim
@@ -203,7 +203,7 @@ function! MbedList()
   " XXX: if @o == "" ??
   if !empty(@o)
     " no output 
-    new
+    new | set buftype = nofile
     silent put=@o
     " Delete empty lines
     execute "g/^$/d"

--- a/plugin/mbed.vim
+++ b/plugin/mbed.vim
@@ -81,7 +81,7 @@ function! MbedGetTargetandToolchain( force )
         return
       endif
     endif
-    let w:mbed_target = l:target
+    let w:mbed_target = substitute(substitute(l:target, '\[[^]]*\] ', '', 'g'), '\n', '', 'g')
   endif
 
   if w:mbed_toolchain == "" || a:force != 0
@@ -95,7 +95,7 @@ function! MbedGetTargetandToolchain( force )
         return
       endif
     endif
-    let w:mbed_toolchain = l:toolchain
+    let w:mbed_toolchain = substitute(substitute(l:target, '\[[^]]*\] ', '', 'g'), '\n', '', 'g')
   endif
 endfunction
 

--- a/plugin/mbed.vim
+++ b/plugin/mbed.vim
@@ -47,13 +47,31 @@
 "   is opened. You can close this buffer with <F9>. 
 "
 
-if !exists( "w:mbed_target" )
+function! ReadTargetandToolchainFromConfigFile(file)
+  if filereadable(a:file)
+    if match(readfile(a:file), "TARGET")
+      let w:mbed_target = system("grep 'TARGET' " . a:file . " | cut -f2 -d=")
+    elseif match(readfile(a:file), "TOOLCHAIN")
+      let w:mbed_toolchain = system("grep 'TOOLCHAIN' " . a:file . " | cut -f2 -d=")
+    endif
+  endif
+endfunction
+
+if !exists("w:mbed_target")
   let w:mbed_target = ""
 endif
 
-if !exists( "w:mbed_toolchain" )
+if !exists("w:mbed_toolchain")
   let w:mbed_toolchain = ""
 endif
+
+" read from ~/.mbed if found
+call ReadTargetandToolchainFromConfigFile("~/.mbed")
+" eventually override the global configuration with the local .mbed file content
+call ReadTargetandToolchainFromConfigFile(".mbed")
+
+" sometimes a line break remains...
+let w:mbed_target = substitute(w:mbed_target, '\n', '', 'g')
 
 function! MbedGetTargetandToolchain( force )
   call system("which mbed")
@@ -200,7 +218,6 @@ endfunction
 
 function! MbedList()
   let @o = system("mbed ls")
-  " XXX: if @o == "" ??
   if !empty(@o)
     " no output 
     new | set buftype = nofile


### PR DESCRIPTION
First major version

* Strenghten mbed target/toolchain checks.

* `mbed_[target|toolchain]` are window-scoped, enables multiple simultaneous sessions with differents targets or toolchains.

* `mbed ls` buffer is a **nofile** type, it can be directly closed with `:q`.

* `w:mbed_[target|toolchain]` are set by default to values read in **~/.mbed** file and eventually overwritten using the local **.mbed** file.

Fixes #12 , fixes #15 , fixes #14 , closes #16 